### PR TITLE
htpasswd to htdigest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ __$DAV_SVN_CONF/dav_svn.passwd__
 
 To add a new User like 'testuser' with password 'test' use the following command
 
-    htdigest -c $DAV_SVN_CONF/dav_svn.passwd testuser
+    htdigest -c $DAV_SVN_CONF/dav_svn.passwd Subversion testuser
 
 Or if you're to lazy, just use this line for your file (for testing only!)
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ __$DAV_SVN_CONF/dav_svn.passwd__
 
 To add a new User like 'testuser' with password 'test' use the following command
 
-    htpasswd -c $DAV_SVN_CONF/dav_svn.passwd testuser
+    htdigest -c $DAV_SVN_CONF/dav_svn.passwd testuser
 
 Or if you're to lazy, just use this line for your file (for testing only!)
 
-    testuser:$apr1$A2fjdj5R$hx9HvwAuj.i5niRjHEMnA.
+    testuser:Subversion:5d1b8d8c9a69af4b0180cdafe09cb907
 
 ## Run the container
 


### PR DESCRIPTION
This container's Apache uses digest authentication, but README.md tells to use htpasswd.
So this PR replaces from htpasswd to htdigest.

This is the configuration of `/etc/apache2/mods-enabled/dav_svn.conf`

```
<Location /svn/>
        DAV svn
        SVNParentPath /var/local/svn/
        SVNListParentPath on

        AuthzSVNAccessFile /etc/apache2/dav_svn/dav_svn.authz

        Satisfy any
        Require valid-user
        AuthType Digest
        AuthName "Subversion"
        AuthUserFile /etc/apache2/dav_svn/dav_svn.passwd
</Location>
```